### PR TITLE
Added tags in UploadMetadata and supported putting objects with tagging

### DIFF
--- a/src/main/java/io/openepcis/s3/provider/AmazonS3ServiceImpl.java
+++ b/src/main/java/io/openepcis/s3/provider/AmazonS3ServiceImpl.java
@@ -44,7 +44,6 @@ public class AmazonS3ServiceImpl implements AmazonS3Service {
   public void verifyBucket() {
     try {
       client.headBucket(HeadBucketRequest.builder().bucket(config.bucket()).build());
-      return;
     } catch (NoSuchBucketException e) {
       client.createBucket(CreateBucketRequest.builder().bucket(config.bucket()).build());
     }
@@ -74,11 +73,7 @@ public class AmazonS3ServiceImpl implements AmazonS3Service {
   @Override
   public Uni<UploadResult> putAsync(String key, InputStream in, Optional<Long> contentLength) {
     return putAsync(
-        key,
-        in,
-        UploadMetadata.builder()
-            .contentLength(contentLength.isPresent() ? contentLength.get() : null)
-            .build());
+        key, in, UploadMetadata.builder().contentLength(contentLength.orElse(null)).build());
   }
 
   @Override


### PR DESCRIPTION
This PR adds a `tags` field to the `UploadMetadata` and enables putting objects with tagging in the s3 bucket. Kindly request you to review the code and approve the PR.